### PR TITLE
Added hdr_scale(), swapped CString uses for \0-terminated byte slices.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oidn"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Will Usher <will@willusher.io>"]
 build = "build.rs"
 homepage = "https://github.com/Twinklebear/oidn-rs"
@@ -8,9 +8,7 @@ documentation = "http://www.willusher.io/oidn-rs/oidn/"
 repository = "https://github.com/Twinklebear/oidn-rs"
 readme = "README.md"
 license = "MIT"
-description = """
-A wrapper for the Intel OpenImageDenoise image denoising library.
-"""
+description = "A wrapper for the Intel OpenImageDenoise image denoising library."
 keywords = ["openimagedenoise", "denoise", "denoising"]
 exclude = [
     ".travis.yml",
@@ -19,4 +17,3 @@ exclude = [
     ".gitignore",
     "examples/*"
 ]
-


### PR DESCRIPTION
Forgot: I also moved the code supplying a normal pass under the condition checking for albedo. This is trivial but avoids a test for `Some(normal)` that is never ran if albedo is absent.
