### PR TITLE
Fix exposure parameter (denoise_exr)

### DIFF
--- a/examples/denoise_exr/src/main.rs
+++ b/examples/denoise_exr/src/main.rs
@@ -140,10 +140,11 @@ fn main() {
         println!("Error denosing image: {}", e.1);
     }
 
+    let exposure = 2.0_f32.powf(args.flag_e);
     let output_img = (0..color.img.len())
         .into_par_iter()
         .map(|i| {
-            let p = linear_to_srgb(tonemap(color.img[i] * args.flag_e));
+            let p = linear_to_srgb(tonemap(color.img[i] * exposure));
             if p < 0.0 {
                 0u8
             } else if p > 1.0 {


### PR DESCRIPTION
Hi Will,

A small fix on the exposure parameter for denoise_exr. Indeed, I was surprised to see a black image when I used `-e 0` :) 
This small fix address this issue. 

Best,