### PR TITLE
Add proper "links" entry to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
     "examples/*",
     "scripts/*"
 ]
+links = "OpenImageDenoise"
 
 [dependencies]
 num_enum = "0.5.1"


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts for more info on why this is useful.

TL;DR - it allows more flexible control over how OpenImageDenoise is linked in.