### PR TITLE
Add testing for buffers

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -35,7 +35,7 @@ impl Device {
     ///
     /// Raw buffer must have been created by this device
     pub unsafe fn create_buffer_from_raw(&self, buffer: OIDNBuffer) -> Buffer {
-        let size = oidnGetBufferSize(buffer);
+        let size = oidnGetBufferSize(buffer) / mem::size_of::<f32>();
         Buffer {
             buf: buffer,
             size,
@@ -73,7 +73,7 @@ impl Buffer {
     }
     /// Reads from the buffer
     pub fn read(&mut self) -> Vec<f32> {
-        let contents = vec![0.0; self.size * mem::size_of::<f32>()];
+        let contents = vec![0.0; self.size];
         unsafe {
             oidnReadBuffer(
                 self.buf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub mod device;
 pub mod filter;
 #[allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 pub mod sys;
+#[cfg(test)]
+mod tests;
 
 #[doc(inline)]
 pub use buffer::Buffer;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,43 @@
+use std::mem;
+
+#[cfg(test)]
+#[test]
+fn buffer_read_write() {
+    let device = crate::Device::new();
+    let mut buffer = match device.create_buffer(&[0.0]) {
+        Some(buffer) => buffer,
+        // resources failing to be created is not the fault of this library
+        None => {
+            eprintln!("Test skipped due to buffer creation failing");
+            return;
+        }
+    };
+    buffer.write(&[1.0]).unwrap();
+    assert_eq!(buffer.read(), vec![1.0]);
+    let mut slice = vec![0.0];
+    buffer.read_to_slice(&mut slice).unwrap();
+    assert_eq!(slice, vec![1.0]);
+    if let Err((err, str)) = device.get_error() {
+        panic!("test failed with {err:?}: {str}")
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_import_read_write() {
+    let device = crate::Device::new();
+    let raw_buffer = unsafe { crate::sys::oidnNewBuffer(device.raw(), mem::size_of::<f32>()) };
+    if raw_buffer.is_null() {
+        eprintln!("Test skipped due to buffer creation failing");
+        return;
+    }
+    let mut buffer = unsafe { device.create_buffer_from_raw(raw_buffer) };
+    buffer.write(&[1.0]).unwrap();
+    assert_eq!(buffer.read(), vec![1.0]);
+    let mut slice = vec![0.0];
+    buffer.read_to_slice(&mut slice).unwrap();
+    assert_eq!(slice, vec![1.0]);
+    if let Err((err, str)) = device.get_error() {
+        panic!("test failed with {err:?}: {str}")
+    }
+}


### PR DESCRIPTION
I noticed that the `read()` function on the added buffers was overallocating its buffers due to multiplying the length, which caused odd errors in some applications (not the example). This was due to converting the size to the size in bytes. The inverse failed to happen in import external buffer. This adds tests to check for this, these tests failed before the lengths were changed.

NOTE: these tests are not run in CI.