### PR TITLE
Fix incorrect assignment of normal input to albedo buffer

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -81,7 +81,7 @@ impl<'a> RayTracing<'a> {
             }
         }) {
             None => {
-                self.albedo = Some(self.device.create_buffer(normal).unwrap());
+                self.normal = Some(self.device.create_buffer(normal).unwrap());
             }
             Some(buf) => {
                 buf.write(normal)


### PR DESCRIPTION
Spent a good while wondering why there were these odd, but quite subtle discolorations in the output of my toy pathtracer. 
Things got weirder when low resolution runs brought them out nicely and revealed the denoiser was _somehow_ hallucinating the colors of the normal input onto the beauty image:
<img width="320" height="256" alt="denoised_thistool_" src="https://github.com/user-attachments/assets/700ced0d-a281-4c3e-9e40-35e965517fac" />

But, long story short, there is a mean little mix-up in the code when making use of both the albedo and normal aux inputs. Fixed as of the commit below :)