### PR TITLE
feat: add optional bundled OIDN binaries feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,11 @@ env:
 jobs:
     build_linux:
         runs-on: ubuntu-latest
-        strategy:
-          matrix:
-            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: actions-rs/toolchain@v1
+              uses: dtolnay/rust-toolchain@stable
               with:
-                toolchain: ${{ matrix.rust_channel }}
-                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (Linux)
               id: cache-oidn
@@ -33,10 +28,17 @@ jobs:
             - run: tar -xf oidn-${OIDN_VERSION}.x86_64.linux.tar.gz
             - run: echo "OIDN_DIR=`pwd`/oidn-${OIDN_VERSION}.x86_64.linux" >> $GITHUB_ENV
             - run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OIDN_DIR}/lib" >> $GITHUB_ENV
-            - run: rustup update
             - run: cargo build --all --all-targets
             - run: cargo clippy --all --all-targets -- -D warnings
             - run: cargo test --all --all-targets
+            - name: Test bundled download and extraction (Linux)
+              run: cargo test -p oidn --all-targets --features bundled
+              env:
+                  LD_LIBRARY_PATH: ""
+            - name: Lint bundled build (Linux)
+              run: cargo clippy -p oidn --all-targets --features bundled -- -D warnings
+              env:
+                  LD_LIBRARY_PATH: ""
             - run: cargo doc --all --no-deps --document-private-items
               env:
                   RUSTDOCFLAGS: -Dwarnings
@@ -44,16 +46,11 @@ jobs:
               run: cargo fmt -- --check
     build_mac:
         runs-on: macos-latest
-        strategy:
-          matrix:
-            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: actions-rs/toolchain@v1
+              uses: dtolnay/rust-toolchain@stable
               with:
-                toolchain: ${{ matrix.rust_channel }}
-                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (macOS)
               id: cache-oidn
@@ -68,21 +65,25 @@ jobs:
             - run: echo "OIDN_DIR=`pwd`/oidn-${OIDN_VERSION}.arm64.macos" >> $GITHUB_ENV
             - run: echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${OIDN_DIR}/lib" >> $GITHUB_ENV
             - run: cp $OIDN_DIR/lib/*dylib .
-            - run: rustup update
             - run: cargo build --all --all-targets
             - run: cargo clippy --all --all-targets -- -D warnings
+            - name: Build bundled feature (macOS)
+              run: cargo build -p oidn --all-targets --features bundled
+              env:
+                  DYLD_LIBRARY_PATH: ""
+                  OIDN_BUNDLED_DIR: ${{ github.workspace }}/oidn-${{ env.OIDN_VERSION }}.arm64.macos
+            - name: Test bundled feature (macOS)
+              run: cargo test -p oidn --all-targets --features bundled
+              env:
+                  DYLD_LIBRARY_PATH: ""
+                  OIDN_BUNDLED_DIR: ${{ github.workspace }}/oidn-${{ env.OIDN_VERSION }}.arm64.macos
     build_windows:
         runs-on: windows-latest
-        strategy:
-          matrix:
-            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: actions-rs/toolchain@v1
+              uses: dtolnay/rust-toolchain@stable
               with:
-                toolchain: ${{ matrix.rust_channel }}
-                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (Windows)
               id: cache-oidn
@@ -97,11 +98,18 @@ jobs:
               if: steps.cache-oidn.outputs.cache-hit != 'true'
               run: wget https://github.com/OpenImageDenoise/oidn/releases/download/v${env:OIDN_VERSION}/oidn-${env:OIDN_VERSION}.x64.windows.zip
             - run: 7z x oidn-${env:OIDN_VERSION}.x64.windows.zip -y
-            - run: rustup update
             - run: |
                 $env:OIDN_DIR="${env:GITHUB_WORKSPACE}/oidn-${env:OIDN_VERSION}.x64.windows/"
                 cargo build --all --all-targets
             - run: |
                 $env:OIDN_DIR="${env:GITHUB_WORKSPACE}/oidn-${env:OIDN_VERSION}.x64.windows/"
                 cargo clippy --all --all-targets -- -D warnings
+            - name: Build bundled feature (Windows)
+              run: cargo build -p oidn --all-targets --features bundled
+              env:
+                  OIDN_BUNDLED_DIR: ${{ github.workspace }}/oidn-${{ env.OIDN_VERSION }}.x64.windows
+            - name: Test bundled feature (Windows)
+              run: cargo test -p oidn --all-targets --features bundled
+              env:
+                  OIDN_BUNDLED_DIR: ${{ github.workspace }}/oidn-${{ env.OIDN_VERSION }}.x64.windows
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,16 @@ env:
 jobs:
     build_linux:
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: actions-rs/toolchain@v1
               with:
+                toolchain: ${{ matrix.rust_channel }}
+                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (Linux)
               id: cache-oidn
@@ -28,6 +33,7 @@ jobs:
             - run: tar -xf oidn-${OIDN_VERSION}.x86_64.linux.tar.gz
             - run: echo "OIDN_DIR=`pwd`/oidn-${OIDN_VERSION}.x86_64.linux" >> $GITHUB_ENV
             - run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${OIDN_DIR}/lib" >> $GITHUB_ENV
+            - run: rustup update
             - run: cargo build --all --all-targets
             - run: cargo clippy --all --all-targets -- -D warnings
             - run: cargo test --all --all-targets
@@ -46,11 +52,16 @@ jobs:
               run: cargo fmt -- --check
     build_mac:
         runs-on: macos-latest
+        strategy:
+          matrix:
+            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: actions-rs/toolchain@v1
               with:
+                toolchain: ${{ matrix.rust_channel }}
+                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (macOS)
               id: cache-oidn
@@ -65,6 +76,7 @@ jobs:
             - run: echo "OIDN_DIR=`pwd`/oidn-${OIDN_VERSION}.arm64.macos" >> $GITHUB_ENV
             - run: echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${OIDN_DIR}/lib" >> $GITHUB_ENV
             - run: cp $OIDN_DIR/lib/*dylib .
+            - run: rustup update
             - run: cargo build --all --all-targets
             - run: cargo clippy --all --all-targets -- -D warnings
             - name: Build bundled feature (macOS)
@@ -79,11 +91,16 @@ jobs:
                   OIDN_BUNDLED_DIR: ${{ github.workspace }}/oidn-${{ env.OIDN_VERSION }}.arm64.macos
     build_windows:
         runs-on: windows-latest
+        strategy:
+          matrix:
+            rust_channel: [stable, beta, nightly]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: actions-rs/toolchain@v1
               with:
+                toolchain: ${{ matrix.rust_channel }}
+                override: true
                 components: rustfmt, clippy
             - name: Cache OIDN download (Windows)
               id: cache-oidn
@@ -98,6 +115,7 @@ jobs:
               if: steps.cache-oidn.outputs.cache-hit != 'true'
               run: wget https://github.com/OpenImageDenoise/oidn/releases/download/v${env:OIDN_VERSION}/oidn-${env:OIDN_VERSION}.x64.windows.zip
             - run: 7z x oidn-${env:OIDN_VERSION}.x64.windows.zip -y
+            - run: rustup update
             - run: |
                 $env:OIDN_DIR="${env:GITHUB_WORKSPACE}/oidn-${env:OIDN_VERSION}.x64.windows/"
                 cargo build --all --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,34 @@ readme = "README.md"
 license = "MIT"
 description = "A wrapper for the Intel OpenImageDenoise image denoising library."
 keywords = ["openimagedenoise", "denoise", "denoising"]
-exclude = [
-    ".travis.yml",
-    "*.png",
-    "*.jpg",
-    ".gitignore",
-    "examples/*",
-    "scripts/*",
+include = [
+    "Cargo.toml",
+    "LICENSE.md",
+    "README.md",
+    "build.rs",
+    "src/**",
+    "tests/**",
+    "examples/*.rs",
 ]
 links = "OpenImageDenoise"
+
+
+[features]
+default = []
+bundled = ["dep:flate2", "dep:sha2", "dep:tar", "dep:ureq", "dep:zip"]
 
 [dependencies]
 num_enum = "0.7.6"
 
 [build-dependencies]
+flate2 = { version = "1.1.9", optional = true }
 pkg-config = "0.3.33"
+sha2 = { version = "0.10.9", optional = true }
+tar = { version = "0.4.45", optional = true }
+ureq = { version = "3.3.0", optional = true }
+zip = { version = "8.6.0", default-features = false, features = [
+    "deflate",
+], optional = true }
 
 [dev-dependencies]
 rand = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ exclude = [
 links = "OpenImageDenoise"
 
 [dependencies]
-num_enum = "0.7.3"
+num_enum = "0.7.6"
 
 [build-dependencies]
-pkg-config = "0.3.31"
+pkg-config = "0.3.33"
 
 [dev-dependencies]
-rand = "0.9.0"
-image = "0.25.5"
-exr = "0.9.0"
+rand = "0.10.1"
+image = "0.25.10"
+exr = "1.74.0"
 docopt = "1.1.1"
-rayon = "1.10.0"
-serde = { version = "1.0.218", features = ["derive"] }
+rayon = "1.12.0"
+serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ Rust docs can be found [here](https://docs.rs/oidn).
 
 Open Image Denoise documentation can be found [here](https://openimagedenoise.github.io/documentation.html).
 
+## Bundled OIDN binaries
+
+By default this crate links against an Open Image Denoise installation found
+through `OIDN_DIR` or `pkg-config`. Enable the `bundled` feature to have the
+build script download the matching official Open Image Denoise binary package
+and link against it:
+
+```toml
+oidn = { version = "2.4.1", features = ["bundled"] }
+```
+
+The bundled feature supports the official OIDN packages for x86_64 Linux,
+x86_64 Windows, and x86_64/aarch64 macOS. Downloaded archives are verified
+against pinned SHA-256 checksums for the crate's OIDN version. Set
+`OIDN_BUNDLED_DIR` to a pre-extracted OIDN package root if you want to provide
+the files yourself or avoid a network download during the build. The feature
+still links the dynamic OIDN libraries, so applications that redistribute
+binaries must also ship the runtime libraries from the bundled package's `lib`
+or `bin` directory. For local `cargo run`, examples, and tests, the build
+script copies bundled runtime libraries into the active Cargo target output
+directories and uses relative runtime search paths on Linux and macOS.
+
 ## Example
 
 The crate provides a lightweight wrapper over the Open Image Denoise library,

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,406 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+#[cfg(not(feature = "bundled"))]
 use pkg_config::Config;
+#[cfg(feature = "bundled")]
+use sha2::{Digest, Sha256};
 
 fn main() {
-    if env::var("DOCS_RS").is_err() {
-        if let Ok(dir) = env::var("OIDN_DIR") {
-            let mut lib_path = PathBuf::from(dir);
-            lib_path.push("lib");
-            println!("cargo:rustc-link-search=native={}", lib_path.display());
-        } else {
-            Config::new().probe("OpenImageDenoise").unwrap_or_else(|e| {
-                println!(
-                    "cargo:error=Could not find OpenImageDenoise via pkg-config: {}",
-                    e
-                );
-                panic!("Failed to find OpenImageDenoise");
-            });
-        }
-        println!("cargo:rerun-if-env-changed=OIDN_DIR");
-        println!("cargo:rustc-link-lib=OpenImageDenoise");
+    if env::var("DOCS_RS").is_ok() {
+        return;
     }
+
+    println!("cargo:rerun-if-env-changed=OIDN_BUNDLED_DIR");
+    println!("cargo:rerun-if-env-changed=OIDN_DIR");
+
+    #[cfg(feature = "bundled")]
+    link_bundled_oidn().unwrap_or_else(|e| {
+        println!("cargo:error=Could not prepare bundled OpenImageDenoise: {e}");
+        panic!("Failed to prepare bundled OpenImageDenoise");
+    });
+
+    #[cfg(not(feature = "bundled"))]
+    link_system_oidn();
+
+    println!("cargo:rustc-link-lib=OpenImageDenoise");
+}
+
+#[cfg(not(feature = "bundled"))]
+fn link_system_oidn() {
+    let oidn_dir = env::var("OIDN_DIR").ok();
+    if let Some(lib_path) = oidn_dir.as_deref().and_then(find_oidn_lib_dir) {
+        println!("cargo:rustc-link-search=native={}", lib_path.display());
+    } else if let Err(e) = Config::new().probe("OpenImageDenoise") {
+        if let Some(dir) = oidn_dir {
+            println!(
+                "cargo:warning=OIDN_DIR was set to `{dir}`, but no OpenImageDenoise library was found in that directory or its `lib` subdirectory."
+            );
+        }
+        println!("cargo:error=Could not find OpenImageDenoise via pkg-config: {e}");
+        panic!("Failed to find OpenImageDenoise");
+    }
+}
+
+#[cfg(feature = "bundled")]
+fn link_bundled_oidn() -> Result<(), Box<dyn std::error::Error>> {
+    if let Ok(dir) = env::var("OIDN_BUNDLED_DIR") {
+        let Some(lib_path) = find_oidn_lib_dir(&dir) else {
+            return Err(format!(
+                "OIDN_BUNDLED_DIR was set to `{dir}`, but no OpenImageDenoise library was found in that directory or its `lib` subdirectory"
+            )
+            .into());
+        };
+        let install_dir = bundled_install_dir(Path::new(&dir), &lib_path);
+        link_bundled_lib_dir(&lib_path, &install_dir)?;
+        return Ok(());
+    }
+
+    let package = BundledPackage::for_target()?;
+    let install_dir = prepare_bundled_package(&package)?;
+    let lib_path = install_dir.join("lib");
+
+    if !contains_oidn_library(&lib_path) {
+        return Err(format!(
+            "OpenImageDenoise library was not found in extracted bundle `{}`",
+            lib_path.display()
+        )
+        .into());
+    }
+
+    link_bundled_lib_dir(&lib_path, &install_dir)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn link_bundled_lib_dir(
+    lib_path: &Path,
+    install_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    add_relative_runtime_search_path();
+    match env::var("CARGO_CFG_TARGET_OS").as_deref() {
+        Ok("windows") => copy_runtime_libraries(&install_dir.join("bin"))?,
+        Ok("linux") | Ok("macos") => copy_runtime_libraries(lib_path)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn bundled_install_dir(input_dir: &Path, lib_path: &Path) -> PathBuf {
+    if input_dir.join("bin").is_dir() {
+        input_dir.to_path_buf()
+    } else {
+        lib_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| input_dir.to_path_buf())
+    }
+}
+
+fn find_oidn_lib_dir(dir: &str) -> Option<PathBuf> {
+    let root = PathBuf::from(dir);
+    let lib = root.join("lib");
+    if contains_oidn_library(&lib) {
+        Some(lib)
+    } else if contains_oidn_library(&root) {
+        Some(root)
+    } else {
+        None
+    }
+}
+
+fn contains_oidn_library(path: &Path) -> bool {
+    let Ok(entries) = path.read_dir() else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        name == "OpenImageDenoise.lib"
+            || name == "libOpenImageDenoise.so"
+            || name.starts_with("libOpenImageDenoise.so.")
+            || name == "libOpenImageDenoise.dylib"
+            || name.starts_with("libOpenImageDenoise.") && name.ends_with(".dylib")
+    })
+}
+
+#[cfg(feature = "bundled")]
+#[derive(Clone, Copy)]
+enum ArchiveKind {
+    TarGz,
+    Zip,
+}
+
+#[cfg(feature = "bundled")]
+struct BundledPackage {
+    archive_name: String,
+    install_dir: String,
+    archive_kind: ArchiveKind,
+    expected_sha256: &'static str,
+}
+
+#[cfg(feature = "bundled")]
+impl BundledPackage {
+    fn for_target() -> Result<Self, Box<dyn std::error::Error>> {
+        let version = env!("CARGO_PKG_VERSION");
+        let os = env::var("CARGO_CFG_TARGET_OS")?;
+        let arch = env::var("CARGO_CFG_TARGET_ARCH")?;
+        // Keep these checksums in sync with the OIDN package version above.
+        // The bundled CI job verifies the current host archive against them.
+        let platform = match (os.as_str(), arch.as_str()) {
+            ("linux", "x86_64") => (
+                "x86_64.linux",
+                ArchiveKind::TarGz,
+                "b69ca2443a226ef692ca46bdc4f89995b1e99091f2665b906cbe07e9673e48cc",
+            ),
+            ("macos", "x86_64") => (
+                "x86_64.macos",
+                ArchiveKind::TarGz,
+                "b9addf2855ee36d7768fd02d4d540e64612096487bad302e608d04e639ae1584",
+            ),
+            ("macos", "aarch64") => (
+                "arm64.macos",
+                ArchiveKind::TarGz,
+                "f1d7370bc09242bbd72d405b424ba240fd4d64103f3e607cdfeeaa2f2718cfb8",
+            ),
+            ("windows", "x86_64") => (
+                "x64.windows",
+                ArchiveKind::Zip,
+                "682d94ba57525ed177d73412e0ed903f576867bd048f830a5c6f63c56b25e8b8",
+            ),
+            _ => {
+                return Err(format!(
+                    "the bundled feature does not have an OpenImageDenoise {version} package for target {arch}-{os}"
+                )
+                .into());
+            }
+        };
+        let extension = match platform.1 {
+            ArchiveKind::TarGz => "tar.gz",
+            ArchiveKind::Zip => "zip",
+        };
+        let package_name = format!("oidn-{version}.{}", platform.0);
+
+        Ok(Self {
+            archive_name: format!("{package_name}.{extension}"),
+            install_dir: package_name,
+            archive_kind: platform.1,
+            expected_sha256: platform.2,
+        })
+    }
+
+    fn url(&self) -> String {
+        format!(
+            "https://github.com/OpenImageDenoise/oidn/releases/download/v{}/{}",
+            env!("CARGO_PKG_VERSION"),
+            self.archive_name
+        )
+    }
+}
+
+#[cfg(feature = "bundled")]
+fn prepare_bundled_package(
+    package: &BundledPackage,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").ok_or("OUT_DIR is not set")?);
+    let bundle_dir = out_dir.join("oidn-bundled");
+    let install_dir = bundle_dir.join(&package.install_dir);
+
+    if has_verified_bundle(&install_dir, package.expected_sha256) {
+        return Ok(install_dir);
+    }
+
+    std::fs::create_dir_all(&bundle_dir)?;
+
+    let archive_path = bundle_dir.join(&package.archive_name);
+    if !archive_path.exists() {
+        download_file(&package.url(), &archive_path, package.expected_sha256)?;
+    } else {
+        verify_file_sha256(&archive_path, package.expected_sha256)?;
+    }
+
+    if install_dir.exists() {
+        std::fs::remove_dir_all(&install_dir)?;
+    }
+
+    extract_archive(&archive_path, &bundle_dir, package.archive_kind)?;
+    write_checksum_marker(&install_dir, package.expected_sha256)?;
+    Ok(install_dir)
+}
+
+#[cfg(feature = "bundled")]
+fn download_file(
+    url: &str,
+    destination: &Path,
+    expected_sha256: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_destination = destination.with_extension("download");
+    let mut response = ureq::get(url).call()?;
+    let mut reader = response.body_mut().as_reader();
+    let mut file = std::fs::File::create(&tmp_destination)?;
+    std::io::copy(&mut reader, &mut file)?;
+    drop(file);
+    if let Err(error) = verify_file_sha256(&tmp_destination, expected_sha256) {
+        let _ = std::fs::remove_file(&tmp_destination);
+        return Err(error);
+    }
+    std::fs::rename(tmp_destination, destination)?;
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn verify_file_sha256(
+    path: &Path,
+    expected_sha256: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    let actual_sha256 = hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    if actual_sha256.eq_ignore_ascii_case(expected_sha256) {
+        Ok(())
+    } else {
+        Err(format!(
+            "SHA256 mismatch for `{}`: expected {expected_sha256}, got {actual_sha256}",
+            path.display()
+        )
+        .into())
+    }
+}
+
+#[cfg(feature = "bundled")]
+fn has_verified_bundle(install_dir: &Path, expected_sha256: &str) -> bool {
+    contains_oidn_library(&install_dir.join("lib"))
+        && std::fs::read_to_string(checksum_marker_path(install_dir))
+            .is_ok_and(|checksum| checksum.trim().eq_ignore_ascii_case(expected_sha256))
+}
+
+#[cfg(feature = "bundled")]
+fn write_checksum_marker(
+    install_dir: &Path,
+    expected_sha256: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::write(checksum_marker_path(install_dir), expected_sha256)?;
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn checksum_marker_path(install_dir: &Path) -> PathBuf {
+    install_dir.join(".oidn-rs-bundle.sha256")
+}
+
+#[cfg(feature = "bundled")]
+fn extract_archive(
+    archive_path: &Path,
+    destination: &Path,
+    archive_kind: ArchiveKind,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match archive_kind {
+        ArchiveKind::TarGz => {
+            let file = std::fs::File::open(archive_path)?;
+            let gz = flate2::read::GzDecoder::new(file);
+            tar::Archive::new(gz).unpack(destination)?;
+        }
+        ArchiveKind::Zip => {
+            let file = std::fs::File::open(archive_path)?;
+            zip::ZipArchive::new(file)?.extract(destination)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn add_relative_runtime_search_path() {
+    match env::var("CARGO_CFG_TARGET_OS").as_deref() {
+        Ok("linux") => println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN"),
+        Ok("macos") => println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path"),
+        _ => {}
+    }
+}
+
+#[cfg(feature = "bundled")]
+fn copy_runtime_libraries(source_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let libraries = runtime_libraries(source_dir)?;
+    if libraries.is_empty() {
+        return Err(format!(
+            "no bundled OpenImageDenoise runtime libraries were found in `{}`",
+            source_dir.display()
+        )
+        .into());
+    }
+
+    let profile_dir = target_profile_dir()?;
+    for destination in [
+        profile_dir.clone(),
+        profile_dir.join("deps"),
+        profile_dir.join("examples"),
+    ] {
+        std::fs::create_dir_all(&destination)?;
+        for library in &libraries {
+            let file_name = library.file_name().ok_or_else(|| {
+                format!(
+                    "could not determine bundled runtime library name for `{}`",
+                    library.display()
+                )
+            })?;
+            std::fs::copy(library, destination.join(file_name))?;
+            println!("cargo:rerun-if-changed={}", library.display());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "bundled")]
+fn runtime_libraries(dir: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut libraries = Vec::new();
+    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
+    for entry in dir.read_dir()? {
+        let path = entry?.path();
+        if is_runtime_library(&path, &target_os) {
+            libraries.push(path);
+        }
+    }
+    Ok(libraries)
+}
+
+#[cfg(feature = "bundled")]
+fn is_runtime_library(path: &Path, target_os: &str) -> bool {
+    let Some(file_name) = path.file_name().and_then(|file_name| file_name.to_str()) else {
+        return false;
+    };
+
+    match target_os {
+        "linux" => file_name.ends_with(".so") || file_name.contains(".so."),
+        "macos" => file_name.ends_with(".dylib"),
+        "windows" => path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("dll")),
+        _ => false,
+    }
+}
+
+#[cfg(feature = "bundled")]
+fn target_profile_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").ok_or("OUT_DIR is not set")?);
+    out_dir
+        .ancestors()
+        .nth(3)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "could not determine Cargo target profile directory from OUT_DIR `{}`",
+                out_dir.display()
+            )
+            .into()
+        })
 }

--- a/examples/async_buffers.rs
+++ b/examples/async_buffers.rs
@@ -1,0 +1,54 @@
+extern crate oidn;
+
+use oidn::{Device, Quality, RayTracing, Storage};
+
+const WIDTH: usize = 2;
+const HEIGHT: usize = 1;
+const PIXELS: usize = WIDTH * HEIGHT * 3;
+
+fn main() {
+    let device = Device::cpu();
+    let input = [0.18, 0.22, 0.27, 0.74, 0.68, 0.59];
+
+    let mut color = device
+        .create_buffer_with_storage(PIXELS, Storage::Host)
+        .expect("failed to allocate input buffer");
+    unsafe {
+        device
+            .write_buffer_async(&mut color, &input)
+            .expect("input length should match the buffer")
+            .wait();
+    }
+
+    let mut output = device
+        .create_buffer_with_storage(PIXELS, Storage::Host)
+        .expect("failed to allocate output buffer");
+
+    let mut filter = RayTracing::new(&device);
+    filter
+        .filter_quality(Quality::Balanced)
+        .srgb(true)
+        .image_dimensions(WIDTH, HEIGHT);
+    unsafe {
+        filter
+            .filter_buffer_async(&color, &mut output)
+            .expect("buffer dimensions should match the filter")
+            .wait();
+    }
+
+    let mut denoised = [0.0; PIXELS];
+    unsafe {
+        device
+            .read_buffer_async(&mut output, &mut denoised)
+            .expect("output length should match the buffer")
+            .wait();
+    }
+
+    if let Err(error) = device.get_error() {
+        panic!("Open Image Denoise failed: {}", error.1);
+    }
+
+    for rgb in denoised.chunks_exact(3) {
+        println!("{:.4} {:.4} {:.4}", rgb[0], rgb[1], rgb[2]);
+    }
+}

--- a/examples/buffer.rs
+++ b/examples/buffer.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 
-use rand::Rng;
+use rand::RngExt;
 
 const WIDTH: usize = 128;
 const HEIGHT: usize = 9;

--- a/examples/denoise_exr.rs
+++ b/examples/denoise_exr.rs
@@ -6,10 +6,9 @@ extern crate rayon;
 extern crate serde;
 
 use docopt::Docopt;
-use exr::prelude::rgba_image as rgb_exr;
+use exr::prelude::read_first_rgba_layer_from_file;
 use rayon::prelude::*;
 use serde::Deserialize;
-use std::f32;
 
 /// An example application that shows opening an HDR EXR image with optional
 /// additional normal and albedo EXR images and denoising it with OIDN.
@@ -76,29 +75,27 @@ impl EXRData {
             height,
         }
     }
-    fn set_pixel(&mut self, x: usize, y: usize, pixel: &rgb_exr::Pixel) {
+    fn set_pixel(&mut self, x: usize, y: usize, pixel: (f32, f32, f32, f32)) {
         let i = (y * self.width + x) * 3;
-        self.img[i] = pixel.red.to_f32();
-        self.img[i + 1] = pixel.green.to_f32();
-        self.img[i + 2] = pixel.blue.to_f32();
+        self.img[i] = pixel.0;
+        self.img[i + 1] = pixel.1;
+        self.img[i + 2] = pixel.2;
     }
 }
 
 /// Load an EXR file to an RGB f32 buffer
 fn load_exr(file: &str) -> EXRData {
-    let (_info, image) = rgb_exr::ImageInfo::read_pixels_from_file(
+    read_first_rgba_layer_from_file(
         file,
-        rgb_exr::read_options::high(),
-        |info: &rgb_exr::ImageInfo| -> EXRData {
-            EXRData::new(info.resolution.width(), info.resolution.height())
-        },
-        // set each pixel in the png buffer from the exr file
-        |image: &mut EXRData, pos: rgb_exr::Vec2<usize>, pixel: rgb_exr::Pixel| {
-            image.set_pixel(pos.x(), pos.y(), &pixel);
+        |resolution, _| -> EXRData { EXRData::new(resolution.width(), resolution.height()) },
+        |image: &mut EXRData, pos, pixel: (f32, f32, f32, f32)| {
+            image.set_pixel(pos.x(), pos.y(), pixel);
         },
     )
-    .unwrap();
-    image
+    .unwrap()
+    .layer_data
+    .channel_data
+    .pixels
 }
 
 fn main() {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,14 +1,17 @@
-use crate::Device;
 use crate::sys::{
-    OIDNBuffer, oidnGetBufferSize, oidnNewBuffer, oidnReadBuffer, oidnReleaseBuffer,
-    oidnWriteBuffer,
+    OIDNBuffer, oidnGetBufferData, oidnGetBufferSize, oidnGetBufferStorage, oidnNewBuffer,
+    oidnNewBufferWithStorage, oidnReadBuffer, oidnReadBufferAsync, oidnReleaseBuffer,
+    oidnRetainBuffer, oidnWriteBuffer, oidnWriteBufferAsync,
 };
+use crate::{Device, Storage};
 use std::mem;
+use std::os::raw::c_void;
 use std::sync::Arc;
 
 pub struct Buffer {
     pub(crate) buf: OIDNBuffer,
     pub(crate) size: usize,
+    pub(crate) byte_size: usize,
     pub(crate) device_arc: Arc<u8>,
 }
 
@@ -29,24 +32,120 @@ impl Device {
         Some(Buffer {
             buf: buffer,
             size: contents.len(),
+            byte_size,
             device_arc: self.1.clone(),
         })
     }
+
+    /// Creates a new uninitialized buffer with the requested storage mode.
+    ///
+    /// The size is expressed as a number of `f32` values to match the rest of
+    /// the safe buffer API.
+    pub fn create_buffer_with_storage(&self, len: usize, storage: Storage) -> Option<Buffer> {
+        let byte_size = len.checked_mul(mem::size_of::<f32>())?;
+        let buffer =
+            unsafe { oidnNewBufferWithStorage(self.0, byte_size, storage.as_raw_oidn_storage()) };
+        if buffer.is_null() {
+            None
+        } else {
+            Some(Buffer {
+                buf: buffer,
+                size: len,
+                byte_size,
+                device_arc: self.1.clone(),
+            })
+        }
+    }
+
     /// # Safety
     /// Raw buffer must not be invalid (e.g. destroyed, null ect.)
     ///
     /// Raw buffer must have been created by this device
     pub unsafe fn create_buffer_from_raw(&self, buffer: OIDNBuffer) -> Buffer {
-        let size = unsafe { oidnGetBufferSize(buffer) } / mem::size_of::<f32>();
+        let byte_size = unsafe { oidnGetBufferSize(buffer) };
+        let size = byte_size / mem::size_of::<f32>();
         Buffer {
             buf: buffer,
             size,
+            byte_size,
             device_arc: self.1.clone(),
         }
     }
 
     pub(crate) fn same_device_as_buf(&self, buf: &Buffer) -> bool {
         self.1.as_ref() as *const _ as isize == buf.device_arc.as_ref() as *const _ as isize
+    }
+
+    /// Starts an asynchronous write to an OIDN buffer.
+    ///
+    /// The returned guard keeps the buffer and source slice borrowed until the
+    /// device has been synchronized. Dropping the guard synchronizes the
+    /// device as a convenience, but leaking it prevents synchronization.
+    ///
+    /// # Safety
+    ///
+    /// The returned guard must not be leaked with mechanisms such as
+    /// [`std::mem::forget`] or [`std::mem::ManuallyDrop`]. It must be waited
+    /// or dropped before the source slice or buffer are accessed, mutated, or
+    /// released.
+    pub unsafe fn write_buffer_async<'a>(
+        &'a self,
+        buf: &'a mut Buffer,
+        contents: &'a [f32],
+    ) -> Option<PendingBufferWrite<'a>> {
+        if !self.same_device_as_buf(buf) || buf.size != contents.len() {
+            return None;
+        }
+        unsafe {
+            oidnWriteBufferAsync(
+                buf.buf,
+                0,
+                mem::size_of_val(contents),
+                contents.as_ptr() as *const _,
+            );
+        }
+        Some(PendingBufferWrite {
+            device: self,
+            _buffer: buf,
+            _contents: contents,
+            complete: false,
+        })
+    }
+
+    /// Starts an asynchronous read from an OIDN buffer.
+    ///
+    /// The returned guard keeps the buffer and destination slice borrowed until
+    /// the device has been synchronized. Dropping the guard synchronizes the
+    /// device as a convenience, but leaking it prevents synchronization.
+    ///
+    /// # Safety
+    ///
+    /// The returned guard must not be leaked with mechanisms such as
+    /// [`std::mem::forget`] or [`std::mem::ManuallyDrop`]. It must be waited
+    /// or dropped before the destination slice or buffer are accessed, mutated,
+    /// or released.
+    pub unsafe fn read_buffer_async<'a>(
+        &'a self,
+        buf: &'a mut Buffer,
+        contents: &'a mut [f32],
+    ) -> Option<PendingBufferRead<'a>> {
+        if !self.same_device_as_buf(buf) || buf.size != contents.len() {
+            return None;
+        }
+        unsafe {
+            oidnReadBufferAsync(
+                buf.buf,
+                0,
+                mem::size_of_val(contents),
+                contents.as_mut_ptr() as *mut _,
+            );
+        }
+        Some(PendingBufferRead {
+            device: self,
+            _buffer: buf,
+            _contents: contents,
+            complete: false,
+        })
     }
 }
 
@@ -71,7 +170,7 @@ impl Buffer {
         } else {
             let byte_size = mem::size_of_val(contents);
             unsafe {
-                oidnReadBuffer(self.buf, 0, byte_size, contents.as_ptr() as *mut _);
+                oidnReadBuffer(self.buf, 0, byte_size, contents.as_mut_ptr() as *mut _);
             }
             Some(())
         }
@@ -79,13 +178,13 @@ impl Buffer {
 
     /// Reads from the buffer
     pub fn read(&self) -> Vec<f32> {
-        let contents = vec![0.0; self.size];
+        let mut contents = vec![0.0; self.size];
         unsafe {
             oidnReadBuffer(
                 self.buf,
                 0,
                 self.size * mem::size_of::<f32>(),
-                contents.as_ptr() as *mut _,
+                contents.as_mut_ptr() as *mut _,
             );
         }
         contents
@@ -95,14 +194,119 @@ impl Buffer {
     pub unsafe fn raw(&self) -> OIDNBuffer {
         self.buf
     }
+
+    /// Returns the size of the buffer in bytes.
+    pub fn byte_size(&self) -> usize {
+        self.byte_size
+    }
+
+    /// Returns the storage mode used by the buffer.
+    pub fn storage(&self) -> Storage {
+        let storage = unsafe { oidnGetBufferStorage(self.buf) };
+        Storage::try_from(storage).unwrap_or(Storage::Undefined)
+    }
+
+    /// Returns the raw data pointer for host-accessible buffers.
+    ///
+    /// This pointer may be null, and dereferencing it is unsafe. OIDN only
+    /// permits host access for host and managed storage.
+    pub fn data_ptr(&self) -> *mut c_void {
+        unsafe { oidnGetBufferData(self.buf) }
+    }
+
+    /// Returns the size of the buffer as a number of `f32` values.
     pub fn size(&self) -> usize {
         self.size
+    }
+}
+
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        unsafe {
+            oidnRetainBuffer(self.buf);
+        }
+        Self {
+            buf: self.buf,
+            size: self.size,
+            byte_size: self.byte_size,
+            device_arc: self.device_arc.clone(),
+        }
+    }
+}
+
+impl From<&Buffer> for Buffer {
+    fn from(buffer: &Buffer) -> Self {
+        buffer.clone()
     }
 }
 
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe { oidnReleaseBuffer(self.buf) }
+    }
+}
+
+/// Completion guard for an asynchronous OIDN buffer write.
+///
+/// Calling [`PendingBufferWrite::wait`] or dropping this guard blocks until
+/// [`Device::sync`] completes.
+#[must_use = "dropping the guard blocks to synchronize; call wait() explicitly when possible"]
+pub struct PendingBufferWrite<'a> {
+    device: &'a Device,
+    _buffer: &'a mut Buffer,
+    _contents: &'a [f32],
+    complete: bool,
+}
+
+impl PendingBufferWrite<'_> {
+    /// Blocks until the asynchronous write has completed.
+    pub fn wait(mut self) {
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if !self.complete {
+            self.device.sync();
+            self.complete = true;
+        }
+    }
+}
+
+impl Drop for PendingBufferWrite<'_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// Completion guard for an asynchronous OIDN buffer read.
+///
+/// Calling [`PendingBufferRead::wait`] or dropping this guard blocks until
+/// [`Device::sync`] completes.
+#[must_use = "dropping the guard blocks to synchronize; call wait() explicitly when possible"]
+pub struct PendingBufferRead<'a> {
+    device: &'a Device,
+    _buffer: &'a mut Buffer,
+    _contents: &'a mut [f32],
+    complete: bool,
+}
+
+impl PendingBufferRead<'_> {
+    /// Blocks until the asynchronous read has completed.
+    pub fn wait(mut self) {
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if !self.complete {
+            self.device.sync();
+            self.complete = true;
+        }
+    }
+}
+
+impl Drop for PendingBufferRead<'_> {
+    fn drop(&mut self) {
+        self.finish();
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -10,7 +10,7 @@ use std::{ffi::CStr, os::raw::c_char, ptr};
 /// other.
 ///
 /// While all API calls on a device are thread-safe, they may be serialized.
-/// Therefor, it is recommended to call from the same thread.
+/// Therefore, it is recommended to call from the same thread.
 pub struct Device(pub(crate) OIDNDevice, pub(crate) Arc<u8>);
 
 impl Device {
@@ -80,6 +80,13 @@ impl Device {
         } else {
             let msg = unsafe { CStr::from_ptr(err_msg).to_string_lossy().to_string() };
             Err((err.try_into().unwrap(), msg))
+        }
+    }
+
+    /// Waits until all asynchronous operations on the device have completed.
+    pub fn sync(&self) {
+        unsafe {
+            oidnSyncDevice(self.0);
         }
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Quality, buffer::Buffer, device::Device, sys::*};
-use std::mem;
+use std::{cell::Cell, mem};
 
 /// A generic ray tracing denoising filter for denoising
 /// images produces with Monte Carlo ray tracing methods
@@ -13,6 +13,9 @@ pub struct RayTracing<'a> {
     input_scale: f32,
     srgb: bool,
     clean_aux: bool,
+    weights: Option<Vec<u8>>,
+    // Tracks whether OIDN currently holds a shared-data pointer into `weights`.
+    weights_set: Cell<bool>,
     img_dims: (usize, usize, usize),
     filter_quality: OIDNQuality,
 }
@@ -32,6 +35,8 @@ impl<'a> RayTracing<'a> {
             input_scale: f32::NAN,
             srgb: false,
             clean_aux: false,
+            weights: None,
+            weights_set: Cell::new(false),
             img_dims: (0, 0, 0),
             filter_quality: 0,
         }
@@ -127,9 +132,11 @@ impl<'a> RayTracing<'a> {
     /// Returns [None] if either buffer was not created by this device
     pub fn albedo_normal_buffer(
         &mut self,
-        albedo: Buffer,
-        normal: Buffer,
+        albedo: impl Into<Buffer>,
+        normal: impl Into<Buffer>,
     ) -> Option<&mut RayTracing<'a>> {
+        let albedo = albedo.into();
+        let normal = normal.into();
         if !self.device.same_device_as_buf(&albedo) || !self.device.same_device_as_buf(&normal) {
             return None;
         }
@@ -145,7 +152,8 @@ impl<'a> RayTracing<'a> {
     /// instead
     ///
     /// Returns [None] if albedo buffer was not created by this device
-    pub fn albedo_buffer(&mut self, albedo: Buffer) -> Option<&mut RayTracing<'a>> {
+    pub fn albedo_buffer(&mut self, albedo: impl Into<Buffer>) -> Option<&mut RayTracing<'a>> {
+        let albedo = albedo.into();
         if !self.device.same_device_as_buf(&albedo) {
             return None;
         }
@@ -197,24 +205,61 @@ impl<'a> RayTracing<'a> {
         self
     }
 
+    /// Set custom trained model weights for the RT filter.
+    ///
+    /// The bytes are copied and kept alive by the filter until new weights are
+    /// supplied or [RayTracing::clear_weights] is called.
+    pub fn weights(&mut self, weights: &[u8]) -> &mut RayTracing<'a> {
+        self.weights = Some(weights.to_vec());
+        if self.weights_set.get() {
+            let weights = self.weights.as_ref().expect("weights were just set");
+            unsafe {
+                oidnSetSharedFilterData(
+                    self.handle,
+                    b"weights\0" as *const _ as _,
+                    weights.as_ptr() as *mut _,
+                    weights.len(),
+                );
+            }
+        }
+        self
+    }
+
+    /// Clear any previously supplied custom model weights.
+    pub fn clear_weights(&mut self) -> &mut RayTracing<'a> {
+        if self.weights_set.get() {
+            unsafe {
+                oidnUnsetFilterData(self.handle, b"weights\0" as *const _ as _);
+            }
+            self.weights_set.set(false);
+        }
+        self.weights = None;
+        self
+    }
+
     /// sets the dimensions of the denoising image, if new width * new height
     /// does not equal old width * old height
     pub fn image_dimensions(&mut self, width: usize, height: usize) -> &mut RayTracing<'a> {
         let buffer_dims = 3 * width * height;
-        match &self.albedo {
-            None => {}
-            Some(buffer) => {
-                if buffer.size != buffer_dims {
-                    self.albedo = None;
-                }
+        let clear_albedo = self
+            .albedo
+            .as_ref()
+            .is_some_and(|buffer| buffer.size != buffer_dims);
+        let clear_normal = self
+            .normal
+            .as_ref()
+            .is_some_and(|buffer| buffer.size != buffer_dims);
+
+        if clear_albedo {
+            self.albedo = None;
+            unsafe {
+                oidnUnsetFilterImage(self.handle, b"albedo\0" as *const _ as _);
             }
         }
-        match &self.normal {
-            None => {}
-            Some(buffer) => {
-                if buffer.size != buffer_dims {
-                    self.normal = None;
-                }
+        if clear_albedo || clear_normal {
+            self.normal = None;
+            unsafe {
+                oidnUnsetFilterImage(self.handle, b"normal\0" as *const _ as _);
             }
         }
         self.img_dims = (width, height, buffer_dims);
@@ -229,12 +274,51 @@ impl<'a> RayTracing<'a> {
         self.execute_filter_buffer(Some(color), output)
     }
 
+    /// Starts filtering buffer-backed images asynchronously.
+    ///
+    /// The returned guard keeps the filter and buffers borrowed until the
+    /// device has been synchronized. Dropping the guard synchronizes the
+    /// device as a convenience, but leaking it prevents synchronization.
+    ///
+    /// # Safety
+    ///
+    /// The returned guard must not be leaked with mechanisms such as
+    /// [`std::mem::forget`] or [`std::mem::ManuallyDrop`]. It must be waited
+    /// or dropped before the filter or buffers are accessed, mutated, or
+    /// released.
+    pub unsafe fn filter_buffer_async<'filter>(
+        &'filter mut self,
+        color: &'filter Buffer,
+        output: &'filter mut Buffer,
+    ) -> Result<PendingFilter<'filter, 'a>, Error> {
+        unsafe { self.execute_filter_buffer_async(Some(color), output) }
+    }
+
     pub fn filter_in_place(&self, color: &mut [f32]) -> Result<(), Error> {
         self.execute_filter(None, color)
     }
 
     pub fn filter_in_place_buffer(&self, color: &Buffer) -> Result<(), Error> {
         self.execute_filter_buffer(None, color)
+    }
+
+    /// Starts in-place filtering on a buffer asynchronously.
+    ///
+    /// The returned guard keeps the filter and buffer borrowed until the device
+    /// has been synchronized. Dropping the guard synchronizes the device as a
+    /// convenience, but leaking it prevents synchronization.
+    ///
+    /// # Safety
+    ///
+    /// The returned guard must not be leaked with mechanisms such as
+    /// [`std::mem::forget`] or [`std::mem::ManuallyDrop`]. It must be waited
+    /// or dropped before the filter or buffer are accessed, mutated, or
+    /// released.
+    pub unsafe fn filter_in_place_buffer_async<'filter>(
+        &'filter mut self,
+        color: &'filter mut Buffer,
+    ) -> Result<PendingFilter<'filter, 'a>, Error> {
+        unsafe { self.execute_filter_buffer_async(None, color) }
     }
 
     fn execute_filter(&self, color: Option<&[f32]>, output: &mut [f32]) -> Result<(), Error> {
@@ -259,6 +343,35 @@ impl<'a> RayTracing<'a> {
     }
 
     fn execute_filter_buffer(&self, color: Option<&Buffer>, output: &Buffer) -> Result<(), Error> {
+        self.configure_filter_buffer(color, output)?;
+        unsafe {
+            oidnExecuteFilter(self.handle);
+        }
+        Ok(())
+    }
+
+    unsafe fn execute_filter_buffer_async<'filter>(
+        &'filter mut self,
+        color: Option<&'filter Buffer>,
+        output: &'filter mut Buffer,
+    ) -> Result<PendingFilter<'filter, 'a>, Error> {
+        self.configure_filter_buffer(color, output)?;
+        unsafe {
+            oidnExecuteFilterAsync(self.handle);
+        }
+        Ok(PendingFilter {
+            filter: self,
+            _color: color,
+            _output: output,
+            complete: false,
+        })
+    }
+
+    fn configure_filter_buffer(
+        &self,
+        color: Option<&Buffer>,
+        output: &Buffer,
+    ) -> Result<(), Error> {
         if let Some(alb) = &self.albedo {
             if alb.size != self.img_dims.2 {
                 return Err(Error::InvalidImageDimensions);
@@ -309,6 +422,9 @@ impl<'a> RayTracing<'a> {
                 color
             }
             None => {
+                if !self.device.same_device_as_buf(output) {
+                    return Err(Error::InvalidArgument);
+                }
                 if output.size != self.img_dims.2 {
                     return Err(Error::InvalidImageDimensions);
                 }
@@ -356,15 +472,23 @@ impl<'a> RayTracing<'a> {
             );
             oidnSetFilterBool(self.handle, b"srgb\0" as *const _ as _, self.srgb);
             oidnSetFilterBool(self.handle, b"clean_aux\0" as *const _ as _, self.clean_aux);
+            if let Some(weights) = &self.weights {
+                oidnSetSharedFilterData(
+                    self.handle,
+                    b"weights\0" as *const _ as _,
+                    weights.as_ptr() as *mut _,
+                    weights.len(),
+                );
+                self.weights_set.set(true);
+            }
 
             oidnSetFilterInt(
                 self.handle,
                 b"quality\0" as *const _ as _,
-                self.filter_quality as i32,
+                self.filter_quality,
             );
 
             oidnCommitFilter(self.handle);
-            oidnExecuteFilter(self.handle);
         }
         Ok(())
     }
@@ -380,3 +504,35 @@ impl Drop for RayTracing<'_> {
 }
 
 unsafe impl Send for RayTracing<'_> {}
+
+/// Completion guard for an asynchronous OIDN filter execution.
+///
+/// Calling [`PendingFilter::wait`] or dropping this guard blocks until
+/// [`Device::sync`] completes.
+#[must_use = "dropping the guard blocks to synchronize; call wait() explicitly when possible"]
+pub struct PendingFilter<'filter, 'device> {
+    filter: &'filter mut RayTracing<'device>,
+    _color: Option<&'filter Buffer>,
+    _output: &'filter mut Buffer,
+    complete: bool,
+}
+
+impl PendingFilter<'_, '_> {
+    /// Blocks until the asynchronous filter execution has completed.
+    pub fn wait(mut self) {
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if !self.complete {
+            self.filter.device.sync();
+            self.complete = true;
+        }
+    }
+}
+
+impl Drop for PendingFilter<'_, '_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -63,13 +63,7 @@ impl<'a> RayTracing<'a> {
     /// # Panics
     /// - if resource creation fails
     pub fn albedo_normal(&mut self, albedo: &[f32], normal: &[f32]) -> &mut RayTracing<'a> {
-        match self.albedo.as_mut().and_then(|buf| {
-            if buf.size == albedo.len() {
-                Some(buf)
-            } else {
-                None
-            }
-        }) {
+        match self.albedo.as_mut().filter(|buf| buf.size == albedo.len()) {
             None => {
                 self.albedo = Some(self.device.create_buffer(albedo).unwrap());
             }
@@ -78,13 +72,7 @@ impl<'a> RayTracing<'a> {
                     .expect("we check if the size is the same already");
             }
         }
-        match self.normal.as_mut().and_then(|buf| {
-            if buf.size == normal.len() {
-                Some(buf)
-            } else {
-                None
-            }
-        }) {
+        match self.normal.as_mut().filter(|buf| buf.size == normal.len()) {
             None => {
                 self.normal = Some(self.device.create_buffer(normal).unwrap());
             }
@@ -102,13 +90,7 @@ impl<'a> RayTracing<'a> {
     /// # Panics
     /// - if resource creation fails
     pub fn albedo(&mut self, albedo: &[f32]) -> &mut RayTracing<'a> {
-        match self.albedo.as_mut().and_then(|buf| {
-            if buf.size == albedo.len() {
-                Some(buf)
-            } else {
-                None
-            }
-        }) {
+        match self.albedo.as_mut().filter(|buf| buf.size == albedo.len()) {
             None => {
                 self.albedo = Some(self.device.create_buffer(albedo).unwrap());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,11 @@ pub mod sys;
 mod tests;
 
 #[doc(inline)]
-pub use buffer::Buffer;
+pub use buffer::{Buffer, PendingBufferRead, PendingBufferWrite};
 #[doc(inline)]
 pub use device::Device;
 #[doc(inline)]
-pub use filter::RayTracing;
+pub use filter::{PendingFilter, RayTracing};
 
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, TryFromPrimitive)]
@@ -78,6 +78,27 @@ impl Quality {
             Quality::Balanced => sys::OIDNQuality_OIDN_QUALITY_BALANCED,
             Quality::High => sys::OIDNQuality_OIDN_QUALITY_HIGH,
             Quality::Fast => sys::OIDNQuality_OIDN_QUALITY_FAST,
+        }
+    }
+}
+
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, TryFromPrimitive, Default)]
+pub enum Storage {
+    #[default]
+    Undefined = sys::OIDNStorage_OIDN_STORAGE_UNDEFINED,
+    Host = sys::OIDNStorage_OIDN_STORAGE_HOST,
+    Device = sys::OIDNStorage_OIDN_STORAGE_DEVICE,
+    Managed = sys::OIDNStorage_OIDN_STORAGE_MANAGED,
+}
+
+impl Storage {
+    pub fn as_raw_oidn_storage(&self) -> sys::OIDNStorage {
+        match self {
+            Storage::Undefined => sys::OIDNStorage_OIDN_STORAGE_UNDEFINED,
+            Storage::Host => sys::OIDNStorage_OIDN_STORAGE_HOST,
+            Storage::Device => sys::OIDNStorage_OIDN_STORAGE_DEVICE,
+            Storage::Managed => sys::OIDNStorage_OIDN_STORAGE_MANAGED,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,31 +1,77 @@
+use crate::{Buffer, Error, Quality, Storage};
 use std::mem;
+
+fn buffer_or_skip(device: &crate::Device, contents: &[f32]) -> Option<Buffer> {
+    match device.create_buffer(contents) {
+        Some(buffer) => Some(buffer),
+        // resources failing to be created is not the fault of this library
+        None => {
+            eprintln!("Test skipped due to buffer creation failing");
+            None
+        }
+    }
+}
+
+fn storage_buffer_or_skip(device: &crate::Device, len: usize, storage: Storage) -> Option<Buffer> {
+    match device.create_buffer_with_storage(len, storage) {
+        Some(buffer) => Some(buffer),
+        // resources failing to be created is not the fault of this library
+        None => {
+            eprintln!("Test skipped due to buffer creation failing");
+            None
+        }
+    }
+}
+
+fn assert_device_ok(device: &crate::Device) {
+    if let Err((err, str)) = device.get_error() {
+        panic!("test failed with {err:?}: {str}")
+    }
+}
+
+fn assert_send<T: Send>() {}
+
+#[cfg(test)]
+#[test]
+fn public_types_remain_send() {
+    assert_send::<crate::Device>();
+    assert_send::<crate::RayTracing<'static>>();
+    assert_send::<Buffer>();
+}
 
 #[cfg(test)]
 #[test]
 fn buffer_read_write() {
-    let device = crate::Device::new();
-    let buffer = match device.create_buffer(&[0.0]) {
-        Some(buffer) => buffer,
-        // resources failing to be created is not the fault of this library
-        None => {
-            eprintln!("Test skipped due to buffer creation failing");
-            return;
-        }
+    let device = crate::Device::cpu();
+    let Some(buffer) = buffer_or_skip(&device, &[0.0]) else {
+        return;
     };
     buffer.write(&[1.0]).unwrap();
     assert_eq!(buffer.read(), vec![1.0]);
     let mut slice = vec![0.0];
     buffer.read_to_slice(&mut slice).unwrap();
     assert_eq!(slice, vec![1.0]);
-    if let Err((err, str)) = device.get_error() {
-        panic!("test failed with {err:?}: {str}")
-    }
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_size_mismatch_paths_return_none() {
+    let device = crate::Device::cpu();
+    let Some(buffer) = buffer_or_skip(&device, &[0.0]) else {
+        return;
+    };
+    assert_eq!(buffer.write(&[1.0, 2.0]), None);
+
+    let mut slice = vec![0.0, 0.0];
+    assert_eq!(buffer.read_to_slice(&mut slice), None);
+    assert_device_ok(&device);
 }
 
 #[cfg(test)]
 #[test]
 fn buffer_import_read_write() {
-    let device = crate::Device::new();
+    let device = crate::Device::cpu();
     let raw_buffer = unsafe { crate::sys::oidnNewBuffer(device.raw(), mem::size_of::<f32>()) };
     if raw_buffer.is_null() {
         eprintln!("Test skipped due to buffer creation failing");
@@ -37,7 +83,618 @@ fn buffer_import_read_write() {
     let mut slice = vec![0.0];
     buffer.read_to_slice(&mut slice).unwrap();
     assert_eq!(slice, vec![1.0]);
-    if let Err((err, str)) = device.get_error() {
-        panic!("test failed with {err:?}: {str}")
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_clone_and_from_keep_raw_buffer_alive() {
+    let device = crate::Device::cpu();
+    let Some(buffer) = buffer_or_skip(&device, &[1.0]) else {
+        return;
+    };
+    let raw = unsafe { buffer.raw() };
+    assert!(!raw.is_null());
+
+    let clone = buffer.clone();
+    drop(buffer);
+    clone.write(&[2.0]).unwrap();
+    assert_eq!(clone.read(), vec![2.0]);
+
+    let converted = Buffer::from(&clone);
+    drop(clone);
+    converted.write(&[3.0]).unwrap();
+    assert_eq!(converted.read(), vec![3.0]);
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn raw_buffer_byte_size_preserves_non_f32_sizes() {
+    let device = crate::Device::cpu();
+    let raw_buffer = unsafe { crate::sys::oidnNewBuffer(device.raw(), 1) };
+    if raw_buffer.is_null() {
+        eprintln!("Test skipped due to buffer creation failing");
+        return;
     }
+    let buffer = unsafe { device.create_buffer_from_raw(raw_buffer) };
+    assert_eq!(buffer.byte_size(), 1);
+    assert_eq!(buffer.size(), 0);
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn create_buffer_with_storage_tracks_host_metadata() {
+    let device = crate::Device::cpu();
+    let Some(buffer) = storage_buffer_or_skip(&device, 2, Storage::Host) else {
+        return;
+    };
+
+    assert_eq!(buffer.size(), 2);
+    assert_eq!(buffer.byte_size(), 2 * mem::size_of::<f32>());
+    assert_eq!(buffer.storage(), Storage::Host);
+    assert!(!buffer.data_ptr().is_null());
+
+    buffer.write(&[2.0, 3.0]).unwrap();
+    assert_eq!(buffer.read(), vec![2.0, 3.0]);
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn create_buffer_with_storage_rejects_len_overflow() {
+    let device = crate::Device::cpu();
+    let overflowing_len = usize::MAX / mem::size_of::<f32>() + 1;
+    assert!(
+        device
+            .create_buffer_with_storage(overflowing_len, Storage::Host)
+            .is_none()
+    );
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_async_read_write_waits_for_completion() {
+    let device = crate::Device::cpu();
+    let Some(mut buffer) = buffer_or_skip(&device, &[0.0, 0.0]) else {
+        return;
+    };
+
+    let source = [4.0, 5.0];
+    unsafe {
+        device
+            .write_buffer_async(&mut buffer, &source)
+            .expect("matching async write should start")
+            .wait();
+    }
+    assert_eq!(buffer.read(), source);
+
+    let mut output = [0.0, 0.0];
+    unsafe {
+        device
+            .read_buffer_async(&mut buffer, &mut output)
+            .expect("matching async read should start")
+            .wait();
+    }
+    assert_eq!(output, source);
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_async_rejects_mismatched_lengths_and_devices() {
+    let device = crate::Device::cpu();
+    let foreign_device = crate::Device::cpu();
+    let Some(mut buffer) = buffer_or_skip(&device, &[0.0]) else {
+        return;
+    };
+
+    assert!(unsafe { device.write_buffer_async(&mut buffer, &[1.0, 2.0]) }.is_none());
+
+    let mut output = [0.0, 0.0];
+    assert!(unsafe { device.read_buffer_async(&mut buffer, &mut output) }.is_none());
+
+    assert!(unsafe { foreign_device.write_buffer_async(&mut buffer, &[1.0]) }.is_none());
+
+    let mut read_target = [0.0];
+    assert!(unsafe { foreign_device.read_buffer_async(&mut buffer, &mut read_target) }.is_none());
+    assert_device_ok(&device);
+    assert_device_ok(&foreign_device);
+}
+
+#[cfg(test)]
+#[test]
+fn buffer_async_guards_sync_on_drop() {
+    let device = crate::Device::cpu();
+    let Some(mut buffer) = buffer_or_skip(&device, &[0.0, 0.0]) else {
+        return;
+    };
+
+    let source = [7.0, 8.0];
+    unsafe {
+        let _guard = device
+            .write_buffer_async(&mut buffer, &source)
+            .expect("matching async write should start");
+    }
+    assert_eq!(buffer.read(), source);
+
+    let mut output = [0.0, 0.0];
+    unsafe {
+        let _guard = device
+            .read_buffer_async(&mut buffer, &mut output)
+            .expect("matching async read should start");
+    }
+    assert_eq!(output, source);
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn filter_buffer_paths_execute_and_wait_for_async_guards() {
+    let device = crate::Device::cpu();
+    let color_data = [0.2, 0.3, 0.4];
+    let Some(color) = buffer_or_skip(&device, &color_data) else {
+        return;
+    };
+    let Some(output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut async_output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut in_place) = buffer_or_skip(&device, &color_data) else {
+        return;
+    };
+    let Some(in_place_sync) = buffer_or_skip(&device, &color_data) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter
+        .hdr(false)
+        .srgb(true)
+        .clean_aux(true)
+        .input_scale(1.0)
+        .image_dimensions(1, 1);
+
+    filter.filter_buffer(&color, &output).unwrap();
+    filter.filter_in_place_buffer(&in_place_sync).unwrap();
+    unsafe {
+        filter
+            .filter_buffer_async(&color, &mut async_output)
+            .unwrap()
+            .wait();
+        filter
+            .filter_in_place_buffer_async(&mut in_place)
+            .unwrap()
+            .wait();
+    }
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn filter_async_guard_syncs_on_drop() {
+    let device = crate::Device::cpu();
+    let color_data = [0.2, 0.3, 0.4];
+    let Some(color) = buffer_or_skip(&device, &color_data) else {
+        return;
+    };
+    let Some(mut output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut in_place) = buffer_or_skip(&device, &color_data) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(1, 1);
+
+    unsafe {
+        let _guard = filter
+            .filter_buffer_async(&color, &mut output)
+            .expect("matching async filter should start");
+    }
+    unsafe {
+        let _guard = filter
+            .filter_in_place_buffer_async(&mut in_place)
+            .expect("matching in-place async filter should start");
+    }
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn slice_filter_paths_execute_and_validate_dimensions() {
+    let device = crate::Device::cpu();
+    let color = [0.2, 0.3, 0.4];
+    let mut output = [0.0, 0.0, 0.0];
+    let mut in_place = color;
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter
+        .filter_quality(Quality::Default)
+        .hdr(false)
+        .srgb(true)
+        .input_scale(1.0)
+        .image_dimensions(1, 1);
+
+    filter.filter(&color, &mut output).unwrap();
+    filter.filter_in_place(&mut in_place).unwrap();
+
+    let mut too_short = [0.0, 0.0];
+    assert_eq!(
+        filter.filter(&color, &mut too_short),
+        Err(Error::InvalidImageDimensions)
+    );
+    assert_eq!(
+        filter.filter_in_place(&mut too_short),
+        Err(Error::InvalidImageDimensions)
+    );
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn slice_auxiliary_images_are_reused_and_resized() {
+    let device = crate::Device::cpu();
+    let color = [0.1, 0.2, 0.3];
+    let mut output = [0.0, 0.0, 0.0];
+    let larger_color = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
+    let mut larger_output = [0.0; 6];
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter
+        .image_dimensions(1, 1)
+        .albedo(&[0.5, 0.5, 0.5])
+        .albedo_normal(&[0.6, 0.6, 0.6], &[0.0, 0.0, 1.0]);
+    filter.filter(&color, &mut output).unwrap();
+
+    filter.image_dimensions(2, 1);
+    filter.filter(&larger_color, &mut larger_output).unwrap();
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+#[allow(deprecated)]
+fn slice_auxiliary_setters_cover_initial_reuse_and_resize_paths() {
+    let device = crate::Device::cpu();
+    let color = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
+    let mut output = [0.0; 6];
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter
+        .albedo(&[0.5, 0.5, 0.5])
+        .albedo(&[0.6, 0.6, 0.6])
+        .albedo(&[0.6, 0.6, 0.6, 0.7, 0.7, 0.7])
+        .albedo_normal(
+            &[0.6, 0.6, 0.6, 0.7, 0.7, 0.7],
+            &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+        )
+        .albedo_normal(&[0.6, 0.6, 0.6], &[0.0, 0.0, 1.0])
+        .albedo_normal(
+            &[0.7, 0.7, 0.7, 0.8, 0.8, 0.8],
+            &[0.1, 0.0, 1.0, 0.1, 0.0, 1.0],
+        )
+        .hdr_scale(1.0)
+        .image_dimensions(2, 1);
+
+    filter.filter(&color, &mut output).unwrap();
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn albedo_only_filter_executes_without_normal() {
+    let device = crate::Device::cpu();
+    let color = [0.2, 0.3, 0.4];
+    let mut output = [0.0, 0.0, 0.0];
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(1, 1).albedo(&[0.5, 0.5, 0.5]);
+    filter.filter(&color, &mut output).unwrap();
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn filter_buffer_rejects_invalid_dimensions_and_foreign_buffers() {
+    let device = crate::Device::cpu();
+    let foreign_device = crate::Device::cpu();
+    let Some(color) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(foreign_color) = buffer_or_skip(&foreign_device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(foreign_output) = buffer_or_skip(&foreign_device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(2, 1);
+    assert_eq!(
+        filter.filter_buffer(&color, &output),
+        Err(Error::InvalidImageDimensions)
+    );
+
+    filter.image_dimensions(1, 1);
+    assert_eq!(
+        filter.filter_buffer(&foreign_color, &output),
+        Err(Error::InvalidArgument)
+    );
+    assert_eq!(
+        filter.filter_buffer(&color, &foreign_output),
+        Err(Error::InvalidArgument)
+    );
+    assert_eq!(
+        filter.filter_in_place_buffer(&foreign_output),
+        Err(Error::InvalidArgument)
+    );
+    assert_device_ok(&device);
+    assert_device_ok(&foreign_device);
+}
+
+#[cfg(test)]
+#[test]
+fn filter_rejects_auxiliary_buffers_with_invalid_dimensions() {
+    let device = crate::Device::cpu();
+    let Some(color) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(wide_albedo) = buffer_or_skip(&device, &[0.5; 6]) else {
+        return;
+    };
+    let Some(albedo) = buffer_or_skip(&device, &[0.5, 0.5, 0.5]) else {
+        return;
+    };
+    let Some(wide_normal) = buffer_or_skip(&device, &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0]) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(1, 1);
+    assert!(filter.albedo_buffer(&wide_albedo).is_some());
+    assert_eq!(
+        filter.filter_buffer(&color, &output),
+        Err(Error::InvalidImageDimensions)
+    );
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(1, 1);
+    assert!(filter.albedo_normal_buffer(&albedo, &wide_normal).is_some());
+    assert_eq!(
+        filter.filter_buffer(&color, &output),
+        Err(Error::InvalidImageDimensions)
+    );
+
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn filter_async_rejects_invalid_dimensions_and_foreign_buffers() {
+    let device = crate::Device::cpu();
+    let foreign_device = crate::Device::cpu();
+    let Some(color) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(too_short) = buffer_or_skip(&device, &[0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut output) = buffer_or_skip(&device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut too_short_output) = buffer_or_skip(&device, &[0.0, 0.0]) else {
+        return;
+    };
+    let Some(foreign_color) = buffer_or_skip(&foreign_device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+    let Some(mut foreign_output) = buffer_or_skip(&foreign_device, &[0.0, 0.0, 0.0]) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    filter.image_dimensions(1, 1);
+
+    assert!(matches!(
+        unsafe { filter.filter_buffer_async(&too_short, &mut output) },
+        Err(Error::InvalidImageDimensions)
+    ));
+    assert!(matches!(
+        unsafe { filter.filter_buffer_async(&color, &mut too_short_output) },
+        Err(Error::InvalidImageDimensions)
+    ));
+    assert!(matches!(
+        unsafe { filter.filter_buffer_async(&foreign_color, &mut output) },
+        Err(Error::InvalidArgument)
+    ));
+    assert!(matches!(
+        unsafe { filter.filter_buffer_async(&color, &mut foreign_output) },
+        Err(Error::InvalidArgument)
+    ));
+    assert!(matches!(
+        unsafe { filter.filter_in_place_buffer_async(&mut too_short_output) },
+        Err(Error::InvalidImageDimensions)
+    ));
+    assert!(matches!(
+        unsafe { filter.filter_in_place_buffer_async(&mut foreign_output) },
+        Err(Error::InvalidArgument)
+    ));
+    assert_device_ok(&device);
+    assert_device_ok(&foreign_device);
+}
+
+#[cfg(test)]
+#[test]
+fn image_dimensions_drops_stale_aux_buffers() {
+    let device = crate::Device::cpu();
+    let Some(albedo) = buffer_or_skip(&device, &[0.5, 0.5, 0.5]) else {
+        return;
+    };
+    let Some(color) = buffer_or_skip(&device, &[0.0; 6]) else {
+        return;
+    };
+    let Some(output) = buffer_or_skip(&device, &[0.0; 6]) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    assert!(
+        filter
+            .image_dimensions(1, 1)
+            .albedo_buffer(&albedo)
+            .is_some()
+    );
+
+    filter.image_dimensions(2, 1);
+    filter.filter_buffer(&color, &output).unwrap();
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn auxiliary_buffer_setters_reject_foreign_devices() {
+    let device = crate::Device::cpu();
+    let foreign_device = crate::Device::cpu();
+    let Some(albedo) = buffer_or_skip(&device, &[0.5, 0.5, 0.5]) else {
+        return;
+    };
+    let Some(normal) = buffer_or_skip(&device, &[0.0, 0.0, 1.0]) else {
+        return;
+    };
+    let Some(foreign_albedo) = buffer_or_skip(&foreign_device, &[0.5, 0.5, 0.5]) else {
+        return;
+    };
+    let Some(foreign_normal) = buffer_or_skip(&foreign_device, &[0.0, 0.0, 1.0]) else {
+        return;
+    };
+
+    let mut filter = crate::RayTracing::new(&device);
+    assert!(filter.albedo_buffer(&albedo).is_some());
+    assert!(filter.albedo_normal_buffer(&albedo, &normal).is_some());
+    assert!(filter.albedo_buffer(&foreign_albedo).is_none());
+    assert!(
+        filter
+            .albedo_normal_buffer(&foreign_albedo, &normal)
+            .is_none()
+    );
+    assert!(
+        filter
+            .albedo_normal_buffer(&albedo, &foreign_normal)
+            .is_none()
+    );
+    assert_device_ok(&device);
+    assert_device_ok(&foreign_device);
+}
+
+#[cfg(test)]
+#[test]
+fn weights_and_new_enum_variants_are_exposed() {
+    let device = crate::Device::cpu();
+    let mut filter = crate::RayTracing::new(&device);
+    filter.weights(&[1, 2, 3, 4]).clear_weights();
+
+    assert_eq!(
+        Quality::Fast.as_raw_oidn_quality(),
+        crate::sys::OIDNQuality_OIDN_QUALITY_FAST
+    );
+    assert_eq!(
+        Quality::try_from(crate::sys::OIDNQuality_OIDN_QUALITY_FAST),
+        Ok(Quality::Fast)
+    );
+    assert_eq!(
+        Quality::Default.as_raw_oidn_quality(),
+        crate::sys::OIDNQuality_OIDN_QUALITY_DEFAULT
+    );
+    assert_eq!(
+        Quality::Balanced.as_raw_oidn_quality(),
+        crate::sys::OIDNQuality_OIDN_QUALITY_BALANCED
+    );
+    assert_eq!(
+        Quality::High.as_raw_oidn_quality(),
+        crate::sys::OIDNQuality_OIDN_QUALITY_HIGH
+    );
+    assert_eq!(
+        Quality::try_from(crate::sys::OIDNQuality_OIDN_QUALITY_HIGH),
+        Ok(Quality::High)
+    );
+    assert_eq!(
+        Storage::Undefined.as_raw_oidn_storage(),
+        crate::sys::OIDNStorage_OIDN_STORAGE_UNDEFINED
+    );
+    assert_eq!(
+        Storage::Host.as_raw_oidn_storage(),
+        crate::sys::OIDNStorage_OIDN_STORAGE_HOST
+    );
+    assert_eq!(
+        Storage::Managed.as_raw_oidn_storage(),
+        crate::sys::OIDNStorage_OIDN_STORAGE_MANAGED
+    );
+    assert_eq!(
+        Storage::try_from(crate::sys::OIDNStorage_OIDN_STORAGE_DEVICE),
+        Ok(Storage::Device)
+    );
+    assert_eq!(
+        Storage::Device.as_raw_oidn_storage(),
+        crate::sys::OIDNStorage_OIDN_STORAGE_DEVICE
+    );
+    assert_eq!(
+        Error::try_from(crate::sys::OIDNError_OIDN_ERROR_CANCELLED),
+        Ok(Error::Canceled)
+    );
+    assert_eq!(
+        Error::try_from(crate::sys::OIDNError_OIDN_ERROR_INVALID_OPERATION),
+        Ok(Error::InvalidOperation)
+    );
+    assert_eq!(
+        Error::try_from(crate::sys::OIDNError_OIDN_ERROR_UNSUPPORTED_HARDWARE),
+        Ok(Error::UnsupportedFormat)
+    );
+    assert_device_ok(&device);
+}
+
+#[cfg(test)]
+#[test]
+fn optional_devices_can_be_queried() {
+    let _ = crate::Device::sycl();
+    let _ = crate::Device::cuda();
+    let _ = crate::Device::hip();
+    let _ = crate::Device::metal();
+}
+
+#[cfg(test)]
+#[test]
+fn default_new_and_from_raw_devices_are_usable() {
+    let default_device = crate::Device::default();
+    assert_device_ok(&default_device);
+
+    let new_device = crate::Device::new();
+    assert_device_ok(&new_device);
+
+    let raw_device =
+        unsafe { crate::sys::oidnNewDevice(crate::sys::OIDNDeviceType_OIDN_DEVICE_TYPE_CPU) };
+    if raw_device.is_null() {
+        eprintln!("Test skipped due to raw device creation failing");
+        return;
+    }
+    unsafe {
+        crate::sys::oidnCommitDevice(raw_device);
+    }
+    let device = unsafe { crate::Device::from_raw(raw_device) };
+    let Some(buffer) = buffer_or_skip(&device, &[1.0]) else {
+        return;
+    };
+    assert_eq!(buffer.read(), vec![1.0]);
+    assert_device_ok(&device);
 }

--- a/tests/bundled_runtime.rs
+++ b/tests/bundled_runtime.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "bundled")]
+
+use std::fs;
+
+#[test]
+fn bundled_runtime_libraries_are_copied_next_to_test_binary() {
+    let exe = std::env::current_exe().expect("test executable path should be available");
+    let exe_dir = exe
+        .parent()
+        .expect("test executable should have a parent directory");
+
+    let runtime_libraries = fs::read_dir(exe_dir)
+        .expect("test executable directory should be readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(is_oidn_runtime_library)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        !runtime_libraries.is_empty(),
+        "expected bundled OpenImageDenoise runtime libraries next to {}, found none",
+        exe.display()
+    );
+
+    for library in runtime_libraries {
+        assert!(
+            library.metadata().is_ok_and(|metadata| metadata.len() > 0),
+            "bundled runtime library should not be empty: {}",
+            library.display()
+        );
+    }
+}
+
+fn is_oidn_runtime_library(file_name: &str) -> bool {
+    if !file_name.contains("OpenImageDenoise") {
+        return false;
+    }
+
+    if cfg!(target_os = "windows") {
+        file_name.ends_with(".dll")
+    } else if cfg!(target_os = "macos") {
+        file_name.ends_with(".dylib")
+    } else if cfg!(target_os = "linux") {
+        file_name.ends_with(".so") || file_name.contains(".so.")
+    } else {
+        false
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional `bundled` feature for downloading and linking against official OIDN binary packages during the Cargo build.

- Adds `bundled` feature flag
- Downloads the matching official OIDN package when enabled
- Verifies downloaded archives with pinned SHA-256 checksums
- Allows overriding the extracted package via `OIDN_BUNDLED_DIR`
- Copies runtime libraries into Cargo target output directories for local tests/examples
- Adds CI coverage for bundled builds/tests

## Issue links

Helps #28.

## Notes

This does not make OIDN fully statically embedded into the final Rust binary. It helps with the packaging/distribution problem by automating OIDN acquisition and runtime-library placement for builds/tests, but applications still need to redistribute the dynamic OIDN runtime libraries.
